### PR TITLE
Updated NumberParser to parse numbers based on the invariant number format

### DIFF
--- a/Eto.Parse/Parsers/NumberParser.cs
+++ b/Eto.Parse/Parsers/NumberParser.cs
@@ -47,12 +47,13 @@ namespace Eto.Parse.Parsers
 									return false;
 								}
 								var parameters = x.GetParameters();
-								return parameters.Length == 2
+								return parameters.Length == 3
 									&& parameters[0].ParameterType == typeof(string)
-									&& parameters[1].ParameterType == typeof(NumberStyles);
+									&& parameters[1].ParameterType == typeof(NumberStyles)
+									&& parameters[2].ParameterType == typeof(IFormatProvider);
 							});
 #else
-					parseMethod = ValueType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(NumberStyles) }, null);
+					parseMethod = ValueType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider) }, null);
 #endif
 				}
 				args.Pop();
@@ -70,7 +71,7 @@ namespace Eto.Parse.Parsers
 			if (AllowExponent)
 				style |= NumberStyles.AllowExponent;
 
-			return parseMethod.Invoke(null, new object[] { text, style });
+			return parseMethod.Invoke(null, new object[] { text, style, NumberFormatInfo.InvariantInfo });
 		}
 
 		protected override int InnerParse(ParseArgs args)

--- a/Eto.Parse/project.json
+++ b/Eto.Parse/project.json
@@ -24,6 +24,7 @@
 		"netstandard1.3": {
 			"dependencies": {
 				"System.Collections": "4.0.11",
+				"System.Globalization": "4.0.11",
 				"System.IO": "4.1.0",
 				"System.Linq": "4.1.0",
 				"System.Reflection": "4.1.0",


### PR DESCRIPTION
You will still want to rebase your dnx branch to remove the previous commit. I still haven't merged the most recent picoe/Eto.Parse changes. Neither the new or the old work properly in an alternate culture.  